### PR TITLE
Add heroku-postbuild hook to activate webpack on server

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "start": "node ./server/index.js",
     "react-dev": "webpack -d --watch",
-    "server-dev": "nodemon server/index.js"
+    "server-dev": "nodemon server/index.js",
+    "heroku-postbuild": "webpack -p --config ./webpack.config.js --progress"
   },
   "dependencies": {
     "axios": "^0.16.1",


### PR DESCRIPTION
Currently not webpacking anything. Kind of a problem.